### PR TITLE
Refactor: SuccessCode과 ExceptionCode의 HTTP 상태 코드를 enum으로 관리하도록 리팩터링

### DIFF
--- a/server/src/main/java/com/main33/server/response/ExceptionCode.java
+++ b/server/src/main/java/com/main33/server/response/ExceptionCode.java
@@ -4,45 +4,59 @@ import lombok.Getter;
 
 public enum ExceptionCode {
     // 회원가입/로그인/로그아웃 케이스
-    USERNAME_CONFLICT(409, "이미 사용 중인 닉네임입니다."),
-    EMAIL_CONFLICT(409, "이미 사용 중인 이메일입니다."),
-    INVALID_SIGNUP_FORMAT(400, "email은 이메일 형식, userName은 2~10자, password는 7~20자의 영문, 숫자, 특수문자의 조합이어야 합니다."),
-    NON_EXISTENT_EMAIL(404, "등록되지 않은 이메일입니다."),
-    INCORRECT_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
+    USERNAME_CONFLICT(ErrorStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    EMAIL_CONFLICT(ErrorStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    INVALID_SIGNUP_FORMAT(ErrorStatus.BAD_REQUEST, "email은 이메일 형식, userName은 2~10자, password는 7~20자의 영문, 숫자, 특수문자의 조합이어야 합니다."),
+    NON_EXISTENT_EMAIL(ErrorStatus.NOT_FOUND, "등록되지 않은 이메일입니다."),
+    INCORRECT_PASSWORD(ErrorStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     // 회원 정보 케이스
-    INVALID_USERID_FORMAT(400, "잘못된 요청. userId가 누락되었습니다."),
-    INVALID_USER_FORMAT(400, "userName은 2~10자, password는 7~20자의 영문, 숫자, 특수문자의 조합이어야 합니다."),
-    USER_NOT_FOUND(404, "해당 userId를 가진 유저는 존재하지 않습니다."),
+    INVALID_USERID_FORMAT(ErrorStatus.BAD_REQUEST, "잘못된 요청. userId가 누락되었습니다."),
+    INVALID_USER_FORMAT(ErrorStatus.BAD_REQUEST, "userName은 2~10자, password는 7~20자의 영문, 숫자, 특수문자의 조합이어야 합니다."),
+    USER_NOT_FOUND(ErrorStatus.NOT_FOUND, "해당 userId를 가진 유저는 존재하지 않습니다."),
 
     // 레시피 케이스
-    INVALID_RECIPE_NAME_FORMAT(400, "잘못된 요청. recipeName이 누락되었습니다."),
-    NO_MORE_RECIPES(204, "더 이상 불러올 레시피가 없습니다."),
-    REFRIGERATOR_NOT_FOUND(404, "나만의 냉장고 데이터를 찾을 수 없습니다."),
+    INVALID_RECIPE_NAME_FORMAT(ErrorStatus.BAD_REQUEST, "잘못된 요청. recipeName이 누락되었습니다."),
+    REFRIGERATOR_NOT_FOUND(ErrorStatus.NOT_FOUND, "나만의 냉장고 데이터를 찾을 수 없습니다."),
 
     // 댓글 케이스
-    INVALID_COMMENT_FORMAT(400, "댓글은 500자 이하여야 합니다."),
+    INVALID_COMMENT_FORMAT(ErrorStatus.BAD_REQUEST, "댓글은 500자 이하여야 합니다."),
 
     // 검색 케이스
 
     // 좋아요 케이스
 
     // 공통 케이스
-    INVALID_INPUT_FORMAT(400, "하나 이상의 입력 필드가 올바른 형식이 아닙니다."),
+    INVALID_INPUT_FORMAT(ErrorStatus.BAD_REQUEST, "하나 이상의 입력 필드가 올바른 형식이 아닙니다."),
 
 
     // Unauthorized 케이스
-    UNAUTHORIZED_ACCESS(401, "로그인이 필요한 기능입니다."),
-    INVALID_ACCESS(401, "잘못된 접근입니다.");
+    UNAUTHORIZED_ACCESS(ErrorStatus.UNAUTHORIZED, "로그인이 필요한 기능입니다."),
+    INVALID_ACCESS(ErrorStatus.UNAUTHORIZED, "잘못된 접근입니다.");
 
     @Getter
-    private int status;
+    private ErrorStatus errorStatus;
 
     @Getter
     private String message;
 
-    ExceptionCode(int code, String message) {
-        this.status = code;
+    public enum ErrorStatus {
+        BAD_REQUEST(400),
+        UNAUTHORIZED(401),
+        FORBIDDEN(403),
+        NOT_FOUND(404),
+        CONFLICT(409);
+
+        @Getter
+        private final int code;
+
+        ErrorStatus(int code) {
+            this.code = code;
+        }
+    }
+
+    ExceptionCode(ErrorStatus errorStatus, String message) {
+        this.errorStatus = errorStatus;
         this.message = message;
     }
 }

--- a/server/src/main/java/com/main33/server/response/SuccessCode.java
+++ b/server/src/main/java/com/main33/server/response/SuccessCode.java
@@ -4,44 +4,58 @@ import lombok.Getter;
 
 public enum SuccessCode {
     // 회원가입/로그인/로그아웃 케이스
-    SUCCESS_SIGNUP(201, "정상적으로 회원가입되었습니다."),
-    SUCCESS_CHECK_USERNAME(200, "사용 가능한 닉네임입니다"),
-    SUCCESS_CHECK_EMAIL(200, "사용 가능한 이메일입니다"),
-    SUCCESS_LOGIN(200, "로그인에 성공하였습니다."),
-    SUCCESS_LOGOUT(200, "정상적으로 로그아웃처리되었습니다."),
+    SUCCESS_SIGNUP(SuccessStatus.CREATED, "정상적으로 회원가입되었습니다."),
+    SUCCESS_CHECK_USERNAME(SuccessStatus.OK, "사용 가능한 닉네임입니다."),
+    SUCCESS_CHECK_EMAIL(SuccessStatus.OK, "사용 가능한 이메일입니다."),
+    SUCCESS_LOGIN(SuccessStatus.OK, "로그인에 성공하였습니다."),
+    SUCCESS_LOGOUT(SuccessStatus.OK, "정상적으로 로그아웃처리되었습니다."),
 
     // 회원 정보 케이스
-    SUCCESS_UPDATE_PROFILE(200, "유저 데이터 업데이트에 성공했습니다."),
-    SUCCESS_FIND_REFRIGERATOR(200, null),
-    SUCCESS_FIND_PROFILE(200, null),
+    SUCCESS_UPDATE_PROFILE(SuccessStatus.OK, "유저 데이터 업데이트에 성공했습니다."),
+    SUCCESS_FIND_REFRIGERATOR(SuccessStatus.OK, null),
+    SUCCESS_FIND_PROFILE(SuccessStatus.OK, null),
 
     // 레시피 케이스
-    SUCCESS_CREATE_RECIPE(201, "레시피가 성공적으로 등록되었습니다."),
-    SUCCESS_UPDATE_RECIPE(200, "레시피가 성공적으로 수정되었습니다."),
-    SUCCESS_FIND_RECIPES(200, null),
-    SUCCESS_FIND_MORE_RECIPES(200, null),
-    SUCCESS_FIND_RELATED_RECIPES(200, null),
+    SUCCESS_CREATE_RECIPE(SuccessStatus.CREATED, "레시피가 성공적으로 등록되었습니다."),
+    SUCCESS_UPDATE_RECIPE(SuccessStatus.OK, "레시피가 성공적으로 수정되었습니다."),
+    SUCCESS_FIND_RECIPES(SuccessStatus.OK, null),
+    SUCCESS_FIND_MORE_RECIPES(SuccessStatus.OK, null),
+    NO_MORE_RECIPES(SuccessStatus.CREATED, "더 이상 불러올 레시피가 없습니다."),
+    SUCCESS_FIND_RELATED_RECIPES(SuccessStatus.OK, null),
 
     // 댓글 케이스
-    SUCCESS_CREATE_COMMENT(201, "null"),
+    SUCCESS_CREATE_COMMENT(SuccessStatus.CREATED, "null"),
 
     // 검색 케이스
-    SUCCESS_SEARCH(200, null),
+    SUCCESS_SEARCH(SuccessStatus.OK, null),
 
     // 좋아요 케이스
-    SUCCESS_CREATE_LIKE(201, "좋아요가 반영되었습니다."),
+    SUCCESS_CREATE_LIKE(SuccessStatus.CREATED, "좋아요가 반영되었습니다."),
 
     // 공통 케이스
-    SUCCESS_DELETE(204, null);
+    SUCCESS_DELETE(SuccessStatus.NO_CONTENT, null);
 
     @Getter
-    private int status;
+    private SuccessStatus successStatus;
 
     @Getter
     private String message;
 
-    SuccessCode(int code, String message) {
-        this.status = code;
+    public enum SuccessStatus {
+        OK(200),
+        CREATED(201),
+        NO_CONTENT(204);
+
+        @Getter
+        private final int code;
+
+        SuccessStatus(int code) {
+            this.code = code;
+        }
+    }
+
+    SuccessCode(SuccessStatus successStatus, String message) {
+        this.successStatus = successStatus;
         this.message = message;
     }
 }


### PR DESCRIPTION
SuccessCode 열거형 내부와 ExceptionCode 열거형 내부에
각각 SuccessStatus 열거형과 ErrorStatus 열거형을 만들어 HTTP 상태 코드를 열거형으로 관리하도록 리팩터링했습니다.